### PR TITLE
Rename Inno publisher to Jack Devey

### DIFF
--- a/installer/script-x64.iss
+++ b/installer/script-x64.iss
@@ -1,6 +1,6 @@
 #define AppName "Lux"
 #define Version "1.1.1"
-#define Publisher "BanDev"
+#define Publisher "Jack Devey"
 #define URL "https://bandev.uk/lux"
 #define ExeName "lux.exe"
 

--- a/installer/script-x64.iss
+++ b/installer/script-x64.iss
@@ -1,7 +1,7 @@
 #define AppName "Lux"
 #define Version "1.1.1"
 #define Publisher "Jack Devey"
-#define URL "https://bandev.uk/lux"
+#define URL "https://github.com/jackdevey/Lux"
 #define ExeName "lux.exe"
 
 [Setup]

--- a/installer/script-x86.iss
+++ b/installer/script-x86.iss
@@ -1,6 +1,6 @@
 #define AppName "Lux"
 #define Version "1.1.1"
-#define Publisher "BanDev"
+#define Publisher "Jack Devey"
 #define URL "https://bandev.uk/lux"
 #define ExeName "lux.exe"
 

--- a/installer/script-x86.iss
+++ b/installer/script-x86.iss
@@ -1,7 +1,7 @@
 #define AppName "Lux"
 #define Version "1.1.1"
 #define Publisher "Jack Devey"
-#define URL "https://bandev.uk/lux"
+#define URL "https://github.com/jackdevey/Lux"
 #define ExeName "lux.exe"
 
 [Setup]


### PR DESCRIPTION
This is necessary in order for Lux to be put on WinGet under JackDevey.Lux rather than BanDev.Lux.